### PR TITLE
fix: revert Dockerfiles to use pnpm start instead of standalone mode

### DIFF
--- a/packages/kal-admin/Dockerfile
+++ b/packages/kal-admin/Dockerfile
@@ -45,10 +45,13 @@ WORKDIR /app
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
 
-# Copy standalone build output
-COPY --from=builder /app/packages/kal-admin/.next/standalone ./
-COPY --from=builder /app/packages/kal-admin/.next/static ./packages/kal-admin/.next/static
+# Copy everything needed to run
+COPY --from=deps /app/node_modules ./node_modules
+COPY --from=deps /app/packages/kal-admin/node_modules ./packages/kal-admin/node_modules
+COPY --from=builder /app/packages/kal-admin/.next ./packages/kal-admin/.next
 COPY --from=builder /app/packages/kal-admin/public ./packages/kal-admin/public
+COPY --from=builder /app/packages/kal-admin/package.json ./packages/kal-admin/
+COPY --from=builder /app/packages/kal-admin/next.config.ts ./packages/kal-admin/
 
 WORKDIR /app/packages/kal-admin
 
@@ -57,4 +60,4 @@ EXPOSE 3005
 ENV PORT=3005
 ENV HOSTNAME="0.0.0.0"
 
-CMD ["node", "server.js"]
+CMD ["pnpm", "start"]

--- a/packages/kal-admin/next.config.ts
+++ b/packages/kal-admin/next.config.ts
@@ -2,7 +2,6 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   reactCompiler: true,
-  output: 'standalone',
 };
 
 export default nextConfig;

--- a/packages/kal-frontend-chat/Dockerfile
+++ b/packages/kal-frontend-chat/Dockerfile
@@ -51,10 +51,13 @@ WORKDIR /app
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
 
-# Copy standalone build output
-COPY --from=builder /app/packages/kal-frontend-chat/.next/standalone ./
-COPY --from=builder /app/packages/kal-frontend-chat/.next/static ./packages/kal-frontend-chat/.next/static
+# Copy everything needed to run
+COPY --from=deps /app/node_modules ./node_modules
+COPY --from=deps /app/packages/kal-frontend-chat/node_modules ./packages/kal-frontend-chat/node_modules
+COPY --from=builder /app/packages/kal-frontend-chat/.next ./packages/kal-frontend-chat/.next
 COPY --from=builder /app/packages/kal-frontend-chat/public ./packages/kal-frontend-chat/public
+COPY --from=builder /app/packages/kal-frontend-chat/package.json ./packages/kal-frontend-chat/
+COPY --from=builder /app/packages/kal-frontend-chat/next.config.mjs ./packages/kal-frontend-chat/
 
 WORKDIR /app/packages/kal-frontend-chat
 
@@ -63,4 +66,4 @@ EXPOSE 3003
 ENV PORT=3003
 ENV HOSTNAME="0.0.0.0"
 
-CMD ["node", "server.js"]
+CMD ["pnpm", "start"]

--- a/packages/kal-frontend-chat/next.config.mjs
+++ b/packages/kal-frontend-chat/next.config.mjs
@@ -1,7 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-  output: 'standalone',
 };
 
 export default nextConfig;

--- a/packages/kal-frontend/Dockerfile
+++ b/packages/kal-frontend/Dockerfile
@@ -50,10 +50,13 @@ WORKDIR /app
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
 
-# Copy standalone build output
-COPY --from=builder /app/packages/kal-frontend/.next/standalone ./
-COPY --from=builder /app/packages/kal-frontend/.next/static ./packages/kal-frontend/.next/static
+# Copy everything needed to run
+COPY --from=deps /app/node_modules ./node_modules
+COPY --from=deps /app/packages/kal-frontend/node_modules ./packages/kal-frontend/node_modules
+COPY --from=builder /app/packages/kal-frontend/.next ./packages/kal-frontend/.next
 COPY --from=builder /app/packages/kal-frontend/public ./packages/kal-frontend/public
+COPY --from=builder /app/packages/kal-frontend/package.json ./packages/kal-frontend/
+COPY --from=builder /app/packages/kal-frontend/next.config.mjs ./packages/kal-frontend/
 
 WORKDIR /app/packages/kal-frontend
 
@@ -62,4 +65,4 @@ EXPOSE 3000
 ENV PORT=3000
 ENV HOSTNAME="0.0.0.0"
 
-CMD ["node", "server.js"]
+CMD ["pnpm", "start"]

--- a/packages/kal-frontend/next.config.mjs
+++ b/packages/kal-frontend/next.config.mjs
@@ -2,7 +2,6 @@
 const nextConfig = {
   reactStrictMode: true,
   transpilePackages: ['kal-shared'],
-  output: 'standalone',
 };
 
 export default nextConfig;


### PR DESCRIPTION
Standalone mode in monorepos places server.js at the root, not in the package subdirectory, causing "Cannot find module" errors. Reverted to the working approach using pnpm start with node_modules.

## 📝 Description

Brief description of what this PR does.

## 🔗 Related Issue

Fixes #(issue number)

## 🏷️ Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🧹 Code refactoring (no functional changes)
- [ ] 🧪 Test update (adding or updating tests)

## ✅ Checklist

- [ ] I have read the [Contributing Guidelines](docs/contributing.md)
- [ ] My branch is created from `dev` (not `main`)
- [ ] I have run `pnpm lint:fix`
- [ ] I have run `pnpm typecheck`
- [ ] I have tested my changes locally
- [ ] My code follows the project's coding standards
- [ ] I have updated documentation (if applicable)

## 📸 Screenshots (if applicable)

Add screenshots to help explain your changes.

## 🧪 How to Test

Steps to test this PR:

1. ...
2. ...
3. ...

## 📝 Additional Notes

Any additional information reviewers should know.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment infrastructure configuration for kal-admin, kal-frontend, and kal-frontend-chat applications to optimize build and runtime processes. Changes include adjusting how dependencies and assets are packaged in the runtime environment and updating the application startup method.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->