### PR TITLE
fix: use next start directly instead of pnpm in Dockerfile

### DIFF
--- a/packages/kal-frontend-chat/Dockerfile
+++ b/packages/kal-frontend-chat/Dockerfile
@@ -46,24 +46,21 @@ ENV NEXT_TELEMETRY_DISABLED=1
 RUN pnpm --filter kal-frontend-chat build
 
 FROM base AS runner
-WORKDIR /app
+WORKDIR /app/packages/kal-frontend-chat
 
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
 
 # Copy everything needed to run
-COPY --from=deps /app/node_modules ./node_modules
-COPY --from=deps /app/packages/kal-frontend-chat/node_modules ./packages/kal-frontend-chat/node_modules
-COPY --from=builder /app/packages/kal-frontend-chat/.next ./packages/kal-frontend-chat/.next
-COPY --from=builder /app/packages/kal-frontend-chat/public ./packages/kal-frontend-chat/public
-COPY --from=builder /app/packages/kal-frontend-chat/package.json ./packages/kal-frontend-chat/
-COPY --from=builder /app/packages/kal-frontend-chat/next.config.mjs ./packages/kal-frontend-chat/
-
-WORKDIR /app/packages/kal-frontend-chat
+COPY --from=deps /app/packages/kal-frontend-chat/node_modules ./node_modules
+COPY --from=builder /app/packages/kal-frontend-chat/.next ./.next
+COPY --from=builder /app/packages/kal-frontend-chat/public ./public
+COPY --from=builder /app/packages/kal-frontend-chat/package.json ./
+COPY --from=builder /app/packages/kal-frontend-chat/next.config.mjs ./
 
 EXPOSE 3003
 
 ENV PORT=3003
 ENV HOSTNAME="0.0.0.0"
 
-CMD ["pnpm", "start"]
+CMD ["./node_modules/.bin/next", "start"]


### PR DESCRIPTION
Removed dependency on pnpm workspace context in runner stage by using ./node_modules/.bin/next start directly. Also simplified WORKDIR and copy paths.

## 📝 Description

Brief description of what this PR does.

## 🔗 Related Issue

Fixes #(issue number)

## 🏷️ Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🧹 Code refactoring (no functional changes)
- [ ] 🧪 Test update (adding or updating tests)

## ✅ Checklist

- [ ] I have read the [Contributing Guidelines](docs/contributing.md)
- [ ] My branch is created from `dev` (not `main`)
- [ ] I have run `pnpm lint:fix`
- [ ] I have run `pnpm typecheck`
- [ ] I have tested my changes locally
- [ ] My code follows the project's coding standards
- [ ] I have updated documentation (if applicable)

## 📸 Screenshots (if applicable)

Add screenshots to help explain your changes.

## 🧪 How to Test

Steps to test this PR:

1. ...
2. ...
3. ...

## 📝 Additional Notes

Any additional information reviewers should know.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized Docker build configuration for improved efficiency and clarity in the frontend chat service deployment process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->