### PR TITLE
fix: copy root node_modules where next is hoisted by pnpm

### DIFF
--- a/packages/kal-frontend-chat/Dockerfile
+++ b/packages/kal-frontend-chat/Dockerfile
@@ -46,21 +46,24 @@ ENV NEXT_TELEMETRY_DISABLED=1
 RUN pnpm --filter kal-frontend-chat build
 
 FROM base AS runner
-WORKDIR /app/packages/kal-frontend-chat
+WORKDIR /app
 
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
 
-# Copy everything needed to run
-COPY --from=deps /app/packages/kal-frontend-chat/node_modules ./node_modules
-COPY --from=builder /app/packages/kal-frontend-chat/.next ./.next
-COPY --from=builder /app/packages/kal-frontend-chat/public ./public
-COPY --from=builder /app/packages/kal-frontend-chat/package.json ./
-COPY --from=builder /app/packages/kal-frontend-chat/next.config.mjs ./
+# Copy root node_modules (where next is hoisted)
+COPY --from=deps /app/node_modules ./node_modules
+# Copy package files
+COPY --from=builder /app/packages/kal-frontend-chat/.next ./packages/kal-frontend-chat/.next
+COPY --from=builder /app/packages/kal-frontend-chat/public ./packages/kal-frontend-chat/public
+COPY --from=builder /app/packages/kal-frontend-chat/package.json ./packages/kal-frontend-chat/
+COPY --from=builder /app/packages/kal-frontend-chat/next.config.mjs ./packages/kal-frontend-chat/
+
+WORKDIR /app/packages/kal-frontend-chat
 
 EXPOSE 3003
 
 ENV PORT=3003
 ENV HOSTNAME="0.0.0.0"
 
-CMD ["./node_modules/.bin/next", "start"]
+CMD ["node", "../../node_modules/next/dist/bin/next", "start"]


### PR DESCRIPTION
In pnpm monorepos, dependencies like next are hoisted to the root node_modules. Updated CMD to reference next from the correct path.

## 📝 Description

Brief description of what this PR does.

## 🔗 Related Issue

Fixes #(issue number)

## 🏷️ Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🧹 Code refactoring (no functional changes)
- [ ] 🧪 Test update (adding or updating tests)

## ✅ Checklist

- [ ] I have read the [Contributing Guidelines](docs/contributing.md)
- [ ] My branch is created from `dev` (not `main`)
- [ ] I have run `pnpm lint:fix`
- [ ] I have run `pnpm typecheck`
- [ ] I have tested my changes locally
- [ ] My code follows the project's coding standards
- [ ] I have updated documentation (if applicable)

## 📸 Screenshots (if applicable)

Add screenshots to help explain your changes.

## 🧪 How to Test

Steps to test this PR:

1. ...
2. ...
3. ...

## 📝 Additional Notes

Any additional information reviewers should know.
