### PR TITLE
fix(db): use partialFilterExpression for stripeCustomerId unique index

### DIFF
--- a/packages/kal-db/migrations/20260407000001_add_stripe_fields.js
+++ b/packages/kal-db/migrations/20260407000001_add_stripe_fields.js
@@ -19,9 +19,14 @@ export const up = async (db, client) => {
   );
 
   // Create index on stripeCustomerId for webhook lookups
-  await db
-    .collection("users")
-    .createIndex({ stripeCustomerId: 1 }, { sparse: true, unique: true });
+  // Use partialFilterExpression so null values are excluded from uniqueness
+  await db.collection("users").createIndex(
+    { stripeCustomerId: 1 },
+    {
+      unique: true,
+      partialFilterExpression: { stripeCustomerId: { $type: "string" } },
+    }
+  );
 };
 
 export const down = async (db, client) => {

--- a/packages/kal-db/migrations/20260407000004_fix_stripe_customer_id_index.js
+++ b/packages/kal-db/migrations/20260407000004_fix_stripe_customer_id_index.js
@@ -1,0 +1,48 @@
+/**
+ * Migration: Fix stripeCustomerId index using partialFilterExpression
+ *
+ * Safety net for environments where migration 000001 partially applied —
+ * the updateMany set stripeCustomerId: null on all users, but the
+ * createIndex with { sparse: true, unique: true } failed because sparse
+ * indexes still include documents where the field is explicitly null.
+ *
+ * This drops any existing stripeCustomerId index and recreates it with
+ * a partialFilterExpression that only indexes documents where
+ * stripeCustomerId is a string — completely excluding null/missing values
+ * from the uniqueness constraint.
+ */
+
+export const up = async (db, client) => {
+  // Drop the existing index if it exists (may be sparse or broken)
+  await db
+    .collection("users")
+    .dropIndex("stripeCustomerId_1")
+    .catch(() => {});
+
+  // Recreate with partialFilterExpression — only enforce uniqueness on real Stripe IDs
+  await db.collection("users").createIndex(
+    { stripeCustomerId: 1 },
+    {
+      unique: true,
+      partialFilterExpression: { stripeCustomerId: { $type: "string" } },
+    }
+  );
+
+  console.log(
+    "✅ Recreated stripeCustomerId index with partialFilterExpression (string only)"
+  );
+};
+
+export const down = async (db, client) => {
+  // Revert to the sparse unique index from the original migration
+  await db
+    .collection("users")
+    .dropIndex("stripeCustomerId_1")
+    .catch(() => {});
+
+  await db
+    .collection("users")
+    .createIndex({ stripeCustomerId: 1 }, { sparse: true, unique: true });
+
+  console.log("✅ Reverted stripeCustomerId index to sparse unique");
+};


### PR DESCRIPTION
The original migration used { sparse: true, unique: true } which still fails with E11000 when multiple users have stripeCustomerId: null (sparse only skips missing fields, not explicit nulls).

- Fix 000001 in place: replace sparse with partialFilterExpression so only real string Stripe IDs are included in the unique index
- Add 000004 safety net: drops and recreates the index properly for environments where 000001 partially applied

## 📝 Description

Brief description of what this PR does.

## 🔗 Related Issue

Fixes #(issue number)

## 🏷️ Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🧹 Code refactoring (no functional changes)
- [ ] 🧪 Test update (adding or updating tests)

## ✅ Checklist

- [ ] I have read the [Contributing Guidelines](docs/contributing.md)
- [ ] My branch is created from `dev` (not `main`)
- [ ] I have run `pnpm lint:fix`
- [ ] I have run `pnpm typecheck`
- [ ] I have tested my changes locally
- [ ] My code follows the project's coding standards
- [ ] I have updated documentation (if applicable)

## 📸 Screenshots (if applicable)

Add screenshots to help explain your changes.

## 🧪 How to Test

Steps to test this PR:

1. ...
2. ...
3. ...

## 📝 Additional Notes

Any additional information reviewers should know.
