### PR TITLE
fix(db): make email index migration idempotent to stop recurring error

### DIFF
--- a/packages/kal-db/migrations/20260407000002_fix_email_index_sparse.js
+++ b/packages/kal-db/migrations/20260407000002_fix_email_index_sparse.js
@@ -8,6 +8,15 @@
  */
 
 export const up = async (db, client) => {
+  const indexes = await db.collection("users").indexes();
+  const hasEmailIndex = indexes.some((idx) => idx.key?.email === 1);
+
+  if (hasEmailIndex) {
+    // Index already exists (possibly replaced by a later migration) — skip
+    console.log("✅ email index already exists, skipping sparse migration");
+    return;
+  }
+
   // Drop the old non-sparse unique index
   await db
     .collection("users")


### PR DESCRIPTION
Migration 000002 failed on every deploy because the email index was already replaced by migration 000003 (partialFilterExpression). Now checks if an email index exists first and skips if so.

## 📝 Description

Brief description of what this PR does.

## 🔗 Related Issue

Fixes #(issue number)

## 🏷️ Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🧹 Code refactoring (no functional changes)
- [ ] 🧪 Test update (adding or updating tests)

## ✅ Checklist

- [ ] I have read the [Contributing Guidelines](docs/contributing.md)
- [ ] My branch is created from `dev` (not `main`)
- [ ] I have run `pnpm lint:fix`
- [ ] I have run `pnpm typecheck`
- [ ] I have tested my changes locally
- [ ] My code follows the project's coding standards
- [ ] I have updated documentation (if applicable)

## 📸 Screenshots (if applicable)

Add screenshots to help explain your changes.

## 🧪 How to Test

Steps to test this PR:

1. ...
2. ...
3. ...

## 📝 Additional Notes

Any additional information reviewers should know.
