### PR TITLE
fix(db): make email sparse migration a no-op since it's superseded

### DIFF
--- a/packages/kal-db/migrations/20260407000002_fix_email_index_sparse.js
+++ b/packages/kal-db/migrations/20260407000002_fix_email_index_sparse.js
@@ -1,44 +1,16 @@
 /**
  * Migration: Fix email index to allow multiple null emails
  *
- * The original email_1 index was { unique: true } which prevents
- * multiple users from having email: null (e.g. social/phone login users).
- * This changes it to { unique: true, sparse: true } so null values are
- * excluded from the uniqueness constraint.
+ * SUPERSEDED by 20260407000003_fix_email_index_partial.js which uses
+ * partialFilterExpression instead of sparse. This migration is now a
+ * no-op — it exists only so migrate-mongo records it in the changelog
+ * and stops retrying it on every deploy.
  */
 
 export const up = async (db, client) => {
-  const indexes = await db.collection("users").indexes();
-  const hasEmailIndex = indexes.some((idx) => idx.key?.email === 1);
-
-  if (hasEmailIndex) {
-    // Index already exists (possibly replaced by a later migration) — skip
-    console.log("✅ email index already exists, skipping sparse migration");
-    return;
-  }
-
-  // Drop the old non-sparse unique index
-  await db
-    .collection("users")
-    .dropIndex("email_1")
-    .catch(() => {});
-
-  // Recreate as sparse unique — allows multiple null emails
-  await db
-    .collection("users")
-    .createIndex({ email: 1 }, { unique: true, sparse: true });
-
-  console.log("✅ Recreated email index as sparse unique");
+  console.log("✅ email sparse migration skipped (superseded by 000003 partial filter)");
 };
 
 export const down = async (db, client) => {
-  // Revert to original non-sparse unique index
-  await db
-    .collection("users")
-    .dropIndex("email_1")
-    .catch(() => {});
-
-  await db.collection("users").createIndex({ email: 1 }, { unique: true });
-
-  console.log("✅ Reverted email index to non-sparse unique");
+  // Nothing to revert — this migration is a no-op
 };


### PR DESCRIPTION
Migration 000002 (sparse index) was already superseded by 000003 (partialFilterExpression). The previous idempotency fix still failed because the old index was already dropped — leaving no index to detect. Now a pure no-op so migrate-mongo records it and stops retrying.

## 📝 Description

Brief description of what this PR does.

## 🔗 Related Issue

Fixes #(issue number)

## 🏷️ Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🧹 Code refactoring (no functional changes)
- [ ] 🧪 Test update (adding or updating tests)

## ✅ Checklist

- [ ] I have read the [Contributing Guidelines](docs/contributing.md)
- [ ] My branch is created from `dev` (not `main`)
- [ ] I have run `pnpm lint:fix`
- [ ] I have run `pnpm typecheck`
- [ ] I have tested my changes locally
- [ ] My code follows the project's coding standards
- [ ] I have updated documentation (if applicable)

## 📸 Screenshots (if applicable)

Add screenshots to help explain your changes.

## 🧪 How to Test

Steps to test this PR:

1. ...
2. ...
3. ...

## 📝 Additional Notes

Any additional information reviewers should know.
